### PR TITLE
Add respect to `dataclass` default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ py -m pip install git+https://github.com/preocts/softboiled@v1.0.0
 ## Known Limitations
 
 - All dataclass objects within a SoftBoiled dataclass must also be SoftBoiled
-- No default values defined in the dataclass are honored
+
 ---
 
 ## [Example Usage](example/example.py)
@@ -128,7 +128,8 @@ ExampleAPIModel(id=1, name='Example Response v1', details=ExampleAPISubModel(col
 
 Both models will be created without errors. The extra field `status` will be dropped and the missing field `details.true` will be created with a `NoneType` value for `valid_model02`.
 
-The `Type Warning` is indicating that a value was missing and replaced with `None`.  Type-hinting the key as optional (`size: Optional[str]`) eliminates the warning.  Not importing `annotations` will also remove warnings.
+The `Type Warning` is indicating that a value was missing and replaced with `None`.  Type-hinting the key as optional (`size: Optional[str]`) eliminates the warning.  Giving the attribute a default assignment in the dataclass will also remove the warning as the default will be used.
+
 
 ---
 ---
@@ -179,7 +180,7 @@ The concept of the solution to this is straight-forward: Scrub your data before 
 
 The immediate solution seemed to be not to use the built-in `__init__` of the dataclass. Instead, define my own `__init__` which accounted for extra values by ignoring them.  This quickly lead to bulky `__init__` defs in the dataclass definition with duplicated code in each new dataclass model.  There had to be a more programmatic solution.
 
-That lead me to `SoftBoiled`. A decorater for dataclasses. Once wrapped, the dataclass has the incoming key/value data scrubbed. Extra pairs are removed to avoid the `TypeError`. Missing pairs are added with a value of `None`. Nested Dataclasses are treated with the same care.
+That lead me to `SoftBoiled`. A decorater for dataclasses. Once wrapped, the dataclass has the incoming key/value data scrubbed. Extra pairs are removed to avoid the `TypeError`. Missing pairs are added with a value of `None`, if they don't have a default assignment. Nested Dataclasses are treated with the same care.
 
 This leaves creating the model as simple as defining the structure of the dataclass and then unpacking an API's JSON response into it.
 
@@ -188,7 +189,7 @@ This leaves creating the model as simple as defining the structure of the datacl
 
 ## Local developer installation
 
-It is **highly** recommended to use a `venv` for installation. Leveraging a `venv` will ensure the installed dependency files will not impact other python projects.
+It is **highly** recommended to use a [virtual environment](https://docs.python.org/3/library/venv.html) (`venv`) for installation. Leveraging a `venv` will ensure the installed dependency files will not impact other python projects.
 
 Clone this repo and enter root directory of repo:
 ```bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = softboiled
-version = 1.0.0
+version = 1.1.0
 description = Making overly flexible dataclasses
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/softboiled/softboiled.py
+++ b/src/softboiled/softboiled.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import logging
+from dataclasses import MISSING
 from typing import Any
 from typing import Dict
 from typing import Type
@@ -68,11 +69,15 @@ class SoftBoiled:
             obj: The class object that has been decorated
             data: kwargs of the creation call for the decorated class
         """
-
         return_data: Dict[str, Any] = {}
 
         for field in dataclasses.fields(obj):
-            new_value = data[field.name] if field.name in data else None
+
+            if field.name in data:
+                new_value = data[field.name]
+            else:
+                new_value = field.default if field.default is not MISSING else None
+
             return_data.update({field.name: new_value})
 
             if new_value is None and "Optional" not in field.type:

--- a/tests/softboiled_test.py
+++ b/tests/softboiled_test.py
@@ -71,6 +71,21 @@ class NestedNorm:
     data01: str = ""
 
 
+DEFAULT_EXPECTED: Dict[str, Any] = {
+    "data01": "Test 01",
+    "data02": True,
+    "data03": 0,
+}
+
+
+@SoftBoiled
+@dataclasses.dataclass
+class DefaultValues:
+    data01: str = DEFAULT_EXPECTED["data01"]
+    data02: bool = DEFAULT_EXPECTED["data02"]
+    data03: int = DEFAULT_EXPECTED["data03"]
+
+
 def test_registered() -> None:
     _ = TopLayer(**JUST_RIGHT)
 
@@ -126,3 +141,21 @@ def test_too_large() -> None:
         NestedLayer(**INNER_NEST_LARGE),
         NestedLayer(**INNER_NEST_LARGE),
     ]
+
+
+def test_default_values() -> None:
+    """Pass/Fail"""
+    result = DefaultValues()
+
+    assert result.data01 == DEFAULT_EXPECTED["data01"]
+    assert result.data02 == DEFAULT_EXPECTED["data02"]
+    assert result.data03 == DEFAULT_EXPECTED["data03"]
+
+
+def test_set_values_over_default() -> None:
+    """Pass/fail"""
+    result = DefaultValues(data01="Hello", data02=False, data03=10)
+
+    assert result.data01 == "Hello"
+    assert result.data02 is False
+    assert result.data03 == 10


### PR DESCRIPTION
This update adds respect to default values as defined in the dataclass
when creating an instance. If the key/value is provided, it will be
used. Otherwise the default value is used. When no default is set then
`None` is assigned