### PR TITLE
Rename `self` in `__call__`

### DIFF
--- a/src/softboiled/softboiled.py
+++ b/src/softboiled/softboiled.py
@@ -32,9 +32,9 @@ class SoftBoiled:
 
         functools.update_wrapper(self, cls)
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+    def __call__(self__, *args: Any, **kwargs: Any) -> Any:
         """Handles cleaning kwargs before creating dataclass"""
-        return self.cls(*args, **SoftBoiled.cleandata(self.cls, kwargs))
+        return self__.cls(*args, **SoftBoiled.cleandata(self__.cls, kwargs))
 
     def __repr__(self) -> str:
         """Identify has the decorated class"""


### PR DESCRIPTION
Renaming `self` to `self__` in the `__call__` dunder to avoid the
situation that incoming unpacked data has a key with the same name.
`self` is a legal attribute name for a dataclass, although it does raise
linting warnings.

resolves #2 