### PR TITLE
Add EAFP style check for dataclass object

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ A dataclass decorator that cleans the parameters on instance creation to account
 Installation
 **Note**: Replace `1.x.x` with the desired version number or `main` for latest (unstable) version
 
-Install via pip with pypi:
-```
-pip install softboiled==1.x.x
-```
-
 Install via pip with GitHub:
 ```
 # Linux/MacOS

--- a/src/softboiled/softboiled.py
+++ b/src/softboiled/softboiled.py
@@ -11,6 +11,7 @@ import dataclasses
 import functools
 import logging
 import re
+from dataclasses import is_dataclass
 from dataclasses import MISSING
 from typing import Any
 from typing import Dict
@@ -25,6 +26,9 @@ class SoftBoiled:
 
     def __init__(self, cls: Type[Any]) -> None:
         """Wraps a dataclasses.dataclass and registers class name internally"""
+        if not is_dataclass(cls):
+            raise ValueError("Expected dataclass obejct, got %s", type(cls))
+
         self.cls = cls
 
         SoftBoiled.platter.update({cls.__name__: cls})

--- a/tests/softboiled_test.py
+++ b/tests/softboiled_test.py
@@ -9,6 +9,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+import pytest
 from softboiled import SoftBoiled
 
 INNER_NEST_SMALL: Dict[str, Any] = {"data01": "Hi"}
@@ -82,6 +83,15 @@ class DefaultValues:
     data01: str = DEFAULT_EXPECTED["data01"]
     data02: bool = DEFAULT_EXPECTED["data02"]
     data03: int = DEFAULT_EXPECTED["data03"]
+
+
+def test_not_a_dataclass() -> None:
+    """We don't serve your kind here (EAFP)"""
+    with pytest.raises(ValueError):
+
+        @SoftBoiled
+        class NotADataClass:
+            ...
 
 
 def test_registered() -> None:


### PR DESCRIPTION
Small check to provide cleaner errors to the user for when non-dataclass objects are decorated.